### PR TITLE
Fix description of width and height being swapped in help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Usage: mixxc [-w <width>] [-h <height>] [-s <spacing>] [-a <anchor...>] [-A] [-C
 Minimalistic volume mixer.
 
 Options:
-  -w, --width       window height
-  -h, --height      window width
+  -w, --width       window width
+  -h, --height      window height
   -s, --spacing     spacing between clients
   -a, --anchor      screen anchor point: (t)op, (b)ottom, (l)eft, (r)ight
   -A, --active      show only active sinks

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ static APP_BINARY: &str = "mixxc";
 #[derive(argh::FromArgs)]
 ///Minimalistic volume mixer.
 struct Args {
-    /// window height
+    /// window width
     #[argh(option, short = 'w')]
     width: Option<u32>,
 
-    /// window width
+    /// window height
     #[argh(option, short = 'h')]
     height: Option<u32>,
 


### PR DESCRIPTION
Only a small fix, but I noticed that width and height were swapped in the `--help` output (and also in the README). 